### PR TITLE
Use SELinux labels for volumes

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1009,6 +1009,7 @@ func copyEscapable(dst io.Writer, src io.ReadCloser) (written int64, err error) 
 func (container *Container) networkMounts() []execdriver.Mount {
 	var mounts []execdriver.Mount
 	if container.ResolvConfPath != "" {
+		label.SetFileLabel(container.ResolvConfPath, container.MountLabel)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.ResolvConfPath,
 			Destination: "/etc/resolv.conf",
@@ -1017,6 +1018,7 @@ func (container *Container) networkMounts() []execdriver.Mount {
 		})
 	}
 	if container.HostnamePath != "" {
+		label.SetFileLabel(container.HostnamePath, container.MountLabel)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostnamePath,
 			Destination: "/etc/hostname",
@@ -1025,6 +1027,7 @@ func (container *Container) networkMounts() []execdriver.Mount {
 		})
 	}
 	if container.HostsPath != "" {
+		label.SetFileLabel(container.HostsPath, container.MountLabel)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostsPath,
 			Destination: "/etc/hosts",

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -129,6 +129,9 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 		if err != nil {
 			return nil, nil, err
 		}
+		if err := label.Relabel(v.Path(), container.MountLabel, "z"); err != nil {
+			return nil, nil, err
+		}
 
 		if err := container.copyImagePathContent(v, destination); err != nil {
 			return nil, nil, err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1221,13 +1221,13 @@ func (daemon *Daemon) verifyHostConfig(hostConfig *runconfig.HostConfig) ([]stri
 }
 
 func (daemon *Daemon) setHostConfig(container *Container, hostConfig *runconfig.HostConfig) error {
-	if err := daemon.registerMountPoints(container, hostConfig); err != nil {
-		return err
-	}
-
 	container.Lock()
 	defer container.Unlock()
 	if err := parseSecurityOpt(container, hostConfig); err != nil {
+		return err
+	}
+
+	if err := daemon.registerMountPoints(container, hostConfig); err != nil {
 		return err
 	}
 

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -6,10 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/volume"
@@ -23,6 +21,7 @@ type mountPoint struct {
 	RW          bool
 	Volume      volume.Volume `json:"-"`
 	Source      string
+	Relabel     string
 }
 
 func (m *mountPoint) Setup() (string, error) {
@@ -70,10 +69,11 @@ func parseBindMount(spec string, mountLabel string, config *runconfig.Config) (*
 		}
 		bind.RW = rwModes[mode]
 		// check if we need to apply a SELinux label
-		if strings.ContainsAny(mode, "zZ") {
-			if err := label.Relabel(bind.Source, mountLabel, mode); err != nil {
-				return nil, err
-			}
+		switch {
+		case strings.Contains(mode, "z"):
+			bind.Relabel = "z"
+		case strings.Contains(mode, "Z"):
+			bind.Relabel = "Z"
 		}
 	default:
 		return nil, fmt.Errorf("Invalid volume specification: %s", spec)
@@ -203,9 +203,6 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 		}
 	}
 
-	// lock for labels
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	// 3. Read bind mounts
 	for _, b := range hostConfig.Binds {
 		// #10618
@@ -219,28 +216,22 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 		}
 
 		if len(bind.Name) > 0 && len(bind.Driver) > 0 {
-			// set the label
-			if err := label.SetFileCreateLabel(container.MountLabel); err != nil {
-				return fmt.Errorf("Unable to setup default labeling for volume creation %s: %v", bind.Source, err)
-			}
-
 			// create the volume
 			v, err := createVolume(bind.Name, bind.Driver)
 			if err != nil {
-				// reset the label
-				if e := label.SetFileCreateLabel(""); e != nil {
-					logrus.Errorf("Unable to reset labeling for volume creation %s: %v", bind.Source, e)
-				}
 				return err
 			}
 			bind.Volume = v
-
-			// reset the label
-			if err := label.SetFileCreateLabel(""); err != nil {
-				return fmt.Errorf("Unable to reset labeling for volume creation %s: %v", bind.Source, err)
+			bind.Source = v.Path()
+			// Since this is just a named volume and not a typical bind, set to shared mode `z`
+			if bind.Relabel == "" {
+				bind.Relabel = "z"
 			}
 		}
 
+		if err := label.Relabel(bind.Source, container.MountLabel, bind.Relabel); err != nil {
+			return err
+		}
 		binds[bind.Destination] = true
 		mountPoints[bind.Destination] = bind
 	}


### PR DESCRIPTION
Fixes a regression from the volumes refactor where the vfs graphdriver
was setting labels for volumes to `s0` so that they can both be written
to by the container and shared with other containers.
When moving away from vfs this was never re-introduced.
Since this needs to happen regardless of volume driver, this is
implemented outside of the driver.

Fixes issue where `z` and `Z` labels are not set for bind-mounts.
