### PR TITLE
Do not allow name_to_handle_at, as we have already blocked open_by_handle_at

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -824,11 +824,6 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Args:   []*configs.Arg{},
 		},
 		{
-			Name:   "name_to_handle_at",
-			Action: configs.Allow,
-			Args:   []*configs.Arg{},
-		},
-		{
 			Name:   "nanosleep",
 			Action: configs.Allow,
 			Args:   []*configs.Arg{},


### PR DESCRIPTION
Being able to obtain a file handle is no use as we cannot perform
any operation in it, and it may leak kernel state.

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
