### PR TITLE
Allow the waitpid syscall

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -1524,6 +1524,11 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Args:   []*configs.Arg{},
 		},
 		{
+			Name:   "waitpid",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
 			Name:   "write",
 			Action: configs.Allow,
 			Args:   []*configs.Arg{},


### PR DESCRIPTION
This version is sometimes used eg by glibc on x86

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
